### PR TITLE
gitignore: blacklsit nbproject/private/private.xml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /dist/
+nbproject/private/private.xml


### PR DESCRIPTION
Auto-generated by older Netbeans, Netbeans 22 removed this